### PR TITLE
Add .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,32 @@
+# Defaults at https://github.com/bbatsov/rubocop/blob/master/config/default.yml
+
+Rails:
+  Enabled: true
+
+AllCops:
+  DisplayCopNames: true
+  TargetRubyVersion: 2.3
+
+Style/Documentation:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/LambdaCall:
+  Enabled: false
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+Style/MultilineOperationIndentation:
+  EnforcedStyle: indented
+Style/NumericLiterals:
+  Enabled: false
+Style/MultilineBlockChain:
+  Enabled: false
+
+Metrics/AbcSize:
+  Max: 25 # from 15
+Metrics/MethodLength:
+  CountComments: false  # count full line comments?
+  Max: 15 # from 10
+
+Rails/HasAndBelongsToMany:
+  Enabled: false

--- a/flowdock_rails.gemspec
+++ b/flowdock_rails.gemspec
@@ -14,7 +14,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/aaroalan'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/lib/flowdock_rails/version.rb
+++ b/lib/flowdock_rails/version.rb
@@ -1,3 +1,3 @@
 module FlowdockRails
-  VERSION = "0.1.2"
+  VERSION = '0.1.2'.freeze
 end


### PR DESCRIPTION
This is part of a series of PRs to make our repos share the same basic config file with minor variations (e.g., HDS needs an extra disable for file names and its excluded migrations are in a different folder).

Partial Health-eFilings/Health-eFilings#1159